### PR TITLE
Support multiple quotes in sensitive data

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	var tfmaskResourceRegex = getEnv("TFMASK_RESOURCES_REGEX", "(?i)^(random_id).*$")
 
 	// stage.0.action.0.configuration.OAuthToken: "" => "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-	reTfPlanLine := regexp.MustCompile("^( +)([a-zA-Z0-9%._-]+):( +)([\"<])(.*?)([>\"]) +=> +([\"<])(.*?)([>\"])(.*)$")
+	reTfPlanLine := regexp.MustCompile("^( +)([a-zA-Z0-9%._-]+):( +)([\"<])(.*?)([>\"]) +=> +([\"<])(.*)([>\"])(.*)$")
 
 	// random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)
 	reTfPlanStatusLine := regexp.MustCompile("^(.*?): (.*?) +\\(ID: (.*?)\\)$")


### PR DESCRIPTION
We had the case, that sensitive data wasn't masked correctly. We have a Docker config JSON which contains multiple quotes in a field. 

Example: 

`{\"auths\":{\"https://some-registry.io\":{\"username\":\"docker-pull\",\"password\":\`
would result in 
`=> "**"auths\":{\"https://some-registry.io\":{\"username\":\"docker-pull\",\"password\":\`
now results in
`=> "*******************************************************************************************"`

This PR fixes this. Provided tests have been run.

