### PR TITLE
Add tf 0 12 support

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 		"(?i)^(random_id|random_string).*$")
 
 	// Default to tf 0.11, but users can override
-	var tfenv = getEnv("TFENV", "0.11")
+	var tfenv = getEnv("TFENV", "0.12")
 
 	reTfValues := regexp.MustCompile(tfmaskValuesRegex)
 	reTfResource := regexp.MustCompile(tfmaskResourceRegex)

--- a/main.go
+++ b/main.go
@@ -85,10 +85,10 @@ func main() {
 	var tfmaskChar = getEnv("TFMASK_CHAR", "*")
 	// Pattern representing sensitive output
 	var tfmaskValuesRegex = getEnv("TFMASK_VALUES_REGEX",
-		"(?i)^.*(oauth|secret|token|password|key|result).*$")
+		"(?i)^.*(oauth|secret|token|password|key|result|id).*$")
 	// Pattern representing sensitive resource
 	var tfmaskResourceRegex = getEnv("TFMASK_RESOURCES_REGEX",
-		"(?i)^(random_id).*$")
+		"(?i)^(random_id|random_string).*$")
 
 	// Default to tf 0.11, but users can override
 	var tfenv = getEnv("TFENV", "0.11")

--- a/main.go
+++ b/main.go
@@ -18,9 +18,9 @@ type match struct {
 	firstQuote         string // < or "
 	oldValue           string
 	secondQuote        string // > or "
-	thirdQuote         string // < or "
+	thirdQuote         string // < or " or (
 	newValue           string
-	fourthQuote        string // > or "
+	fourthQuote        string // > or " or )
 	postfix            string
 }
 
@@ -90,6 +90,7 @@ func main() {
 	var tfmaskResourceRegex = getEnv("TFMASK_RESOURCES_REGEX",
 		"(?i)^(random_id).*$")
 
+	// Default to tf 0.11, but users can override
 	var tfenv = getEnv("TFENV", "0.11")
 
 	reTfValues := regexp.MustCompile(tfmaskValuesRegex)
@@ -116,6 +117,7 @@ func getCurrentResource(expression expression, currentResource, line string) str
 	reTfApplyCurrentResource := regexp.MustCompile("^([a-z].*?): (.*?)$")
 	if expression.reTfPlanCurrentResource.MatchString(line) {
 		match := expression.reTfPlanCurrentResource.FindStringSubmatch(line)
+		// for tf 0.12 the resource is wrapped in quotes, so remove them
 		strippedResource := strings.Replace(match[expression.resourceIndex],
 			"\"", "", -1)
 		currentResource = strippedResource
@@ -161,9 +163,9 @@ func matchFromLine(reTfPlanLine *regexp.Regexp, line string) match {
 		firstQuote:         subMatch[4],
 		oldValue:           subMatch[5],
 		secondQuote:        subMatch[6], // > or "
-		thirdQuote:         subMatch[7], // < or "
+		thirdQuote:         subMatch[7], // < or " or (
 		newValue:           subMatch[8],
-		fourthQuote:        subMatch[9], // > or "
+		fourthQuote:        subMatch[9], // > or " or )
 		postfix:            subMatch[10],
 	}
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,23 @@ import (
 	"unicode/utf8"
 )
 
+type match struct {
+	leadingWhitespace  string
+	property           string // something like `stage.0.action.0.configuration.OAuthToken`
+	trailingWhitespace string
+	firstQuote         string // < or "
+	oldValue           string
+	secondQuote        string // > or "
+	thirdQuote         string // < or "
+	newValue           string
+	fourthQuote        string // > or "
+	postfix            string
+}
+
+type expression struct {
+	planStatusRegex *regexp.Regexp
+}
+
 func init() {
 	// make sure we only have one process and that it runs on the main thread
 	// (so that ideally, when we Exec, we keep our user switches and stuff)
@@ -25,86 +42,127 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
+var versionedExpressions = map[string]expression{
+	"0.11": expression{
+		planStatusRegex: regexp.MustCompile(
+			"^(.*?): (.*?) +\\(ID: (.*?)\\)$"),
+	},
+	"0.12": expression{
+		planStatusRegex: regexp.MustCompile(
+			"^(.*?): (.*?) +\\[id=(.*?)\\]$"),
+	},
+}
+
 func main() {
 	log.SetFlags(0) // no timestamps on our logs
 
 	// Character used to mask sensitive output
 	var tfmaskChar = getEnv("TFMASK_CHAR", "*")
-
 	// Pattern representing sensitive output
-	var tfmaskValuesRegex = getEnv("TFMASK_VALUES_REGEX", "(?i)^.*(oauth|secret|token|password|key|result).*$")
-
+	var tfmaskValuesRegex = getEnv("TFMASK_VALUES_REGEX",
+		"(?i)^.*(oauth|secret|token|password|key|result).*$")
 	// Pattern representing sensitive resource
-	var tfmaskResourceRegex = getEnv("TFMASK_RESOURCES_REGEX", "(?i)^(random_id).*$")
-
+	var tfmaskResourceRegex = getEnv("TFMASK_RESOURCES_REGEX",
+		"(?i)^(random_id|random_string).*$")
 	// stage.0.action.0.configuration.OAuthToken: "" => "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 	reTfPlanLine := regexp.MustCompile("^( +)([a-zA-Z0-9%._-]+):( +)([\"<])(.*?)([>\"]) +=> +([\"<])(.*)([>\"])(.*)$")
 
-	// random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)
-	reTfPlanStatusLine := regexp.MustCompile("^(.*?): (.*?) +\\(ID: (.*?)\\)$")
-	
-
-	// -/+ random_string.postgres_admin_password (tainted) (new resource required)
-	reTfPlanCurrentResource := regexp.MustCompile("^([~/+-]+) (.*?) +(.*)$")
-	reTfApplyCurrentResource := regexp.MustCompile("^([a-z].*?): (.*?)$")
-	currentResource := ""
+	var tfenv = getEnv("TFENV", "0.11")
 
 	reTfValues := regexp.MustCompile(tfmaskValuesRegex)
 	reTfResource := regexp.MustCompile(tfmaskResourceRegex)
 	scanner := bufio.NewScanner(os.Stdin)
+	versionedExpressions := versionedExpressions[tfenv]
 	for scanner.Scan() {
 		line := scanner.Text()
-		if reTfPlanCurrentResource.MatchString(line) {
-			match := reTfPlanCurrentResource.FindStringSubmatch(line)
-			currentResource = match[2]
-		} else if reTfApplyCurrentResource.MatchString(line) {
-			match := reTfApplyCurrentResource.FindStringSubmatch(line)
-			currentResource = match[1]
-		}
-
-		if reTfPlanStatusLine.MatchString(line) {
-			match := reTfPlanStatusLine.FindStringSubmatch(line)
-			resource := match[1]
-			id := match[3]
-			if reTfResource.MatchString(resource) {
-				line = strings.Replace(line, id, strings.Repeat(tfmaskChar, utf8.RuneCountInString(id)), 1)
-			}
-			fmt.Println(line)
-		} else if reTfPlanLine.MatchString(line) {
-			match := reTfPlanLine.FindStringSubmatch(line)
-			leadingWhitespace := match[1]
-			property := match[2]            // something like `stage.0.action.0.configuration.OAuthToken`
-			trailingWhitespace := match[3]
-			firstQuote := match[4]          // < or "
-			oldValue := match[5] 
-			secondQuote := match[6]         // > or "
-			thirdQuote := match[7]          // < or "
-			newValue := match[8]
-			fourthQuote := match[9]         // > or "
-			postfix := match[10]
-
-			if reTfValues.MatchString(property) || reTfResource.MatchString(currentResource) {
-				// The value inside the "..." or <...>
-				if oldValue != "sensitive" && oldValue != "computed" && oldValue != "<computed" {
-					oldValue = strings.Repeat(tfmaskChar, utf8.RuneCountInString(oldValue))
-				}
-				// The value inside the "..." or <...>
-				if newValue != "sensitive" && newValue != "computed" && newValue != "<computed" {
-					newValue = strings.Repeat(tfmaskChar, utf8.RuneCountInString(newValue))
-				}
-				fmt.Printf("%v%v:%v%v%v%v => %v%v%v%v\n", 
-					leadingWhitespace, property, trailingWhitespace, firstQuote, oldValue, secondQuote, thirdQuote, newValue, fourthQuote, postfix)
-			} else {
-				fmt.Println(line)
-			}
-		} else {
-			// We matched nothing
-			fmt.Println(line)
-		}
+		currentResource := getCurrentResource(line)
+		fmt.Println(processLine(versionedExpressions, reTfPlanLine,
+			reTfResource, reTfValues, tfmaskChar, currentResource, line))
 	}
 
 	if err := scanner.Err(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}
+}
+
+func getCurrentResource(line string) (currentResource string) {
+	// -/+ random_string.postgres_admin_password (tainted) (new resource required)
+	reTfPlanCurrentResource := regexp.MustCompile("^([~/+-]+) (.*?) +(.*)$")
+	reTfApplyCurrentResource := regexp.MustCompile("^([a-z].*?): (.*?)$")
+	if reTfPlanCurrentResource.MatchString(line) {
+		match := reTfPlanCurrentResource.FindStringSubmatch(line)
+		currentResource = match[2]
+	} else if reTfApplyCurrentResource.MatchString(line) {
+		match := reTfApplyCurrentResource.FindStringSubmatch(line)
+		currentResource = match[1]
+	}
+	return
+}
+
+func processLine(expression expression, reTfPlanLine, reTfResource,
+	reTfValues *regexp.Regexp, tfmaskChar, currentResource,
+	line string) string {
+	if expression.planStatusRegex.MatchString(line) {
+		line = planStatus(expression.planStatusRegex, reTfResource, tfmaskChar,
+			line)
+	} else if reTfPlanLine.MatchString(line) {
+		line = planLine(reTfPlanLine, reTfResource, reTfValues,
+			currentResource, tfmaskChar, line)
+	}
+	return line
+}
+
+func planStatus(planStatusRegex, reTfResource *regexp.Regexp, tfmaskChar,
+	line string) string {
+	match := planStatusRegex.FindStringSubmatch(line)
+	resource := match[1]
+	id := match[3]
+	if reTfResource.MatchString(resource) {
+		line = strings.Replace(line, id, strings.Repeat(tfmaskChar,
+			utf8.RuneCountInString(id)), 1)
+	}
+	return line
+}
+
+func matchFromLine(reTfPlanLine *regexp.Regexp, line string) match {
+	subMatch := reTfPlanLine.FindStringSubmatch(line)
+	return match{
+		leadingWhitespace:  subMatch[1],
+		property:           subMatch[2], // something like `stage.0.action.0.configuration.OAuthToken`
+		trailingWhitespace: subMatch[3],
+		firstQuote:         subMatch[4],
+		oldValue:           subMatch[5],
+		secondQuote:        subMatch[6], // > or "
+		thirdQuote:         subMatch[7], // < or "
+		newValue:           subMatch[8],
+		fourthQuote:        subMatch[9], // > or "
+		postfix:            subMatch[10],
+	}
+}
+
+func planLine(reTfPlanLine, reTfResource, reTfValues *regexp.Regexp,
+	currentResource, tfmaskChar, line string) string {
+	match := matchFromLine(reTfPlanLine, line)
+	if reTfValues.MatchString(match.property) ||
+		reTfResource.MatchString(currentResource) {
+		// The value inside the "..." or <...>
+		oldValue := maskValue(match.oldValue, tfmaskChar)
+		// The value inside the "..." or <...>
+		newValue := maskValue(match.newValue, tfmaskChar)
+		line = fmt.Sprintf("%v%v:%v%v%v%v => %v%v%v%v\n",
+			match.leadingWhitespace, match.property, match.trailingWhitespace,
+			match.firstQuote, oldValue, match.secondQuote, match.thirdQuote,
+			newValue, match.fourthQuote, match.postfix)
+	}
+	return line
+}
+
+func maskValue(value, tfmaskChar string) string {
+	if value != "sensitive" && value != "computed" &&
+		value != "<computed" {
+		return strings.Repeat(tfmaskChar,
+			utf8.RuneCountInString(value))
+	}
+	return value
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,46 +7,49 @@ import (
 )
 
 var lineTests = []struct {
-	line           string
-	expectedResult string
-	minorVersion   string
+	currentResource string
+	line            string
+	expectedResult  string
+	minorVersion    string
 }{
 	// tf 0.11 ------------------------------------
-	{"not_secret", "not_secret", "0.11"},
-	{" stage.0.action.0.configuration.OAuthToken: <wefwf> => <dfdff> ",
-		" stage.0.action.0.configuration.OAuthToken: <*****> => <*****> ", "0.11"},
-	{" stage.0.action.0.configuration.OAuthToken: \"wefwf\" => \"dfdff\" ",
-		" stage.0.action.0.configuration.OAuthToken: \"*****\" => \"*****\" ", "0.11"},
-	{" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ",
-		" stage.0.action.0.configuration.DontObfuscate: <*****> => <*****> ", "0.11"},
-	{"random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)",
+	{"random_id.some_id", "not_secret", "not_secret", "0.11"},
+	{"random_id.some_id", " stage.0.action.0.configuration.OAuthToken: <tf.0.11> => <tf.0.11> ",
+		" stage.0.action.0.configuration.OAuthToken: <*******> => <*******> ", "0.11"},
+	{"random_id.some_id", " stage.0.action.0.configuration.OAuthToken: \"tf.0.11\" => \"tf.0.11\" ",
+		" stage.0.action.0.configuration.OAuthToken: \"*******\" => \"*******\" ", "0.11"},
+	{"random_id.some_id", " stage.0.action.0.configuration.DontObfuscate: <tf.0.11> => <tf.0.11> ",
+		" stage.0.action.0.configuration.DontObfuscate: <*******> => <*******> ", "0.11"},
+	{"random_id.some_id", "random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)",
 		"random_id.some_id: Refreshing state... (ID: ********************************************************************************)",
 		"0.11"},
 	// the id value isn't sensitive with random_string.some_password
-	{"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
+	{"random_string.some_password", "random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
 		"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
 		"0.11"},
-	{" id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
+	{"random_id.some_id", " id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
 		" id:               \"**************************************************************************************\" => <computed> (forces new resource)",
 		"0.11"},
 	// tf 0.12 ------------------------------------
-	{"not_secret", "not_secret", "0.12"},
-	{" stage.0.action.0.configuration.OAuthToken: <wefwf> => <dfdff> ",
-		" stage.0.action.0.configuration.OAuthToken: <*****> => <*****> ", "0.12"},
-	{" stage.0.action.0.configuration.OAuthToken: \"wefwf\" => \"dfdff\" ",
-		" stage.0.action.0.configuration.OAuthToken: \"*****\" => \"*****\" ", "0.12"},
-	{" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ",
-		" stage.0.action.0.configuration.DontObfuscate: <*****> => <*****> ", "0.12"},
-	{"random_id.some_id: Refreshing state... [id=itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ]",
+	{"random_id.some_id", "not_secret", "not_secret", "0.12"},
+	{"random_id.some_id", "      ~ result           = \"pkwemfpwmfwf\" -> (known after apply) ",
+		"      ~ result           = \"************\" -> (known after apply) ", "0.12"},
+	{"random_id.some_id", "random_id.some_id: Refreshing state... [id=itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ]",
 		"random_id.some_id: Refreshing state... [id=********************************************************************************]",
 		"0.12"},
+	{"", "random_id.some_id: Creation complete after 0s [id=YfK9aF]",
+		"random_id.some_id: Creation complete after 0s [id=******]",
+		"0.12"},
 	// the id value isn't sensitive with random_string.some_password
-	{"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
+	{"random_string.some_password", "random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
 		"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
 		"0.12"},
-	{" id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
-		" id:               \"**************************************************************************************\" => <computed> (forces new resource)",
-		"0.11"},
+	{"random_id.some_id", " ~ id =               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" -> (known after apply)",
+		" ~ id =               \"**************************************************************************************\" -> (known after apply)",
+		"0.12"},
+	{"", "random_string.some_password: Creation complete after 0s [id=5s80SMs@JJpA8e/h]",
+		"random_string.some_password: Creation complete after 0s [id=5s80SMs@JJpA8e/h]",
+		"0.12"},
 }
 
 func TestProcessLine(t *testing.T) {
@@ -58,13 +61,14 @@ func TestProcessLine(t *testing.T) {
 		var tfmaskValuesRegex = "(?i)^.*(oauth|secret|token|password|key|result).*$"
 		// Pattern representing sensitive resource
 		var tfmaskResourceRegex = "(?i)^(random_id).*$"
-		// stage.0.action.0.configuration.OAuthToken: "" => "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-		reTfPlanLine := regexp.MustCompile("^( +)([a-zA-Z0-9%._-]+):( +)([\"<])(.*?)([>\"]) +=> +([\"<])(.*)([>\"])(.*)$")
-		currentResource := getCurrentResource("random_id.some_id", line)
+
+		versionedExpressions := versionedExpressions[lineTest.minorVersion]
+
+		currentResource := lineTest.currentResource
 		reTfValues := regexp.MustCompile(tfmaskValuesRegex)
 		reTfResource := regexp.MustCompile(tfmaskResourceRegex)
-		result := processLine(versionedExpressions[lineTest.minorVersion],
-			reTfPlanLine, reTfResource, reTfValues, tfmaskChar, currentResource, line)
+		result := processLine(versionedExpressions,
+			reTfResource, reTfValues, tfmaskChar, currentResource, line)
 		result = strings.TrimSuffix(result, "\n")
 		expectedResult := lineTest.expectedResult
 		if result != expectedResult {
@@ -73,7 +77,7 @@ func TestProcessLine(t *testing.T) {
 	}
 }
 
-var currrentResourceTests = []struct {
+var currentResourceTests = []struct {
 	currentResource string
 	line            string
 	expectedResult  string
@@ -90,10 +94,10 @@ var currrentResourceTests = []struct {
 }
 
 func TestGetCurrentResource(t *testing.T) {
-	for _, currrentResourceTest := range currrentResourceTests {
-		result := getCurrentResource(currrentResourceTest.currentResource,
-			currrentResourceTest.line)
-		expectedResult := currrentResourceTest.expectedResult
+	for _, currentResourceTest := range currentResourceTests {
+		result := getCurrentResource(versionedExpressions["0.11"], currentResourceTest.currentResource,
+			currentResourceTest.line)
+		expectedResult := currentResourceTest.expectedResult
 		if result != expectedResult {
 			t.Errorf("Got %s, want %s", result, expectedResult)
 		}
@@ -140,6 +144,28 @@ func TestPlanStatus(t *testing.T) {
 			planStatusTest.line)
 		if result != planStatusTest.expectedResult {
 			t.Errorf("Got %s, want %s", result, planStatusTest.expectedResult)
+		}
+	}
+}
+
+var maskValueTests = []struct {
+	value          string
+	tfmaskChar     string
+	expectedResult string
+}{
+	{"password", "*", "********"},
+	{"password", "@", "@@@@@@@@"},
+	{"sensitive", "*", "sensitive"},
+	{"computed", "*", "computed"},
+	{"<computed", "*", "<computed"},
+	{"known after apply", "*", "known after apply"},
+}
+
+func TestMaskValue(t *testing.T) {
+	for _, maskValueTest := range maskValueTests {
+		result := maskValue(maskValueTest.value, maskValueTest.tfmaskChar)
+		if result != maskValueTest.expectedResult {
+			t.Errorf("Got %s, want %s", result, maskValueTest.expectedResult)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -23,9 +23,8 @@ var lineTests = []struct {
 	{"random_id.some_id", "random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)",
 		"random_id.some_id: Refreshing state... (ID: ********************************************************************************)",
 		"0.11"},
-	// the id value isn't sensitive with random_string.some_password
 	{"random_string.some_password", "random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
-		"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
+		"random_string.some_password: Refreshing state... (ID: ****************)",
 		"0.11"},
 	{"random_id.some_id", " id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
 		" id:               \"**************************************************************************************\" => <computed> (forces new resource)",
@@ -40,15 +39,14 @@ var lineTests = []struct {
 	{"", "random_id.some_id: Creation complete after 0s [id=YfK9aF]",
 		"random_id.some_id: Creation complete after 0s [id=******]",
 		"0.12"},
-	// the id value isn't sensitive with random_string.some_password
 	{"random_string.some_password", "random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
-		"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
+		"random_string.some_password: Refreshing state... [id=****************]",
 		"0.12"},
 	{"random_id.some_id", " ~ id =               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" -> (known after apply)",
 		" ~ id =               \"**************************************************************************************\" -> (known after apply)",
 		"0.12"},
 	{"", "random_string.some_password: Creation complete after 0s [id=5s80SMs@JJpA8e/h]",
-		"random_string.some_password: Creation complete after 0s [id=5s80SMs@JJpA8e/h]",
+		"random_string.some_password: Creation complete after 0s [id=****************]",
 		"0.12"},
 }
 
@@ -58,9 +56,9 @@ func TestProcessLine(t *testing.T) {
 		// Character used to mask sensitive output
 		var tfmaskChar = "*"
 		// Pattern representing sensitive output
-		var tfmaskValuesRegex = "(?i)^.*(oauth|secret|token|password|key|result).*$"
+		var tfmaskValuesRegex = "(?i)^.*(oauth|secret|token|password|key|result|id).*$"
 		// Pattern representing sensitive resource
-		var tfmaskResourceRegex = "(?i)^(random_id).*$"
+		var tfmaskResourceRegex = "(?i)^(random_id|random_string).*$"
 
 		versionedExpressions := versionedExpressions[lineTest.minorVersion]
 

--- a/main_test.go
+++ b/main_test.go
@@ -18,12 +18,16 @@ var lineTests = []struct {
 	{" stage.0.action.0.configuration.OAuthToken: \"wefwf\" => \"dfdff\" ",
 		" stage.0.action.0.configuration.OAuthToken: \"*****\" => \"*****\" ", "0.11"},
 	{" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ",
-		" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ", "0.11"},
+		" stage.0.action.0.configuration.DontObfuscate: <*****> => <*****> ", "0.11"},
 	{"random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)",
 		"random_id.some_id: Refreshing state... (ID: ********************************************************************************)",
 		"0.11"},
+	// the id value isn't sensitive with random_string.some_password
 	{"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
-		"random_string.some_password: Refreshing state... (ID: ****************)",
+		"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
+		"0.11"},
+	{" id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
+		" id:               \"**************************************************************************************\" => <computed> (forces new resource)",
 		"0.11"},
 	// tf 0.12 ------------------------------------
 	{"not_secret", "not_secret", "0.12"},
@@ -32,13 +36,17 @@ var lineTests = []struct {
 	{" stage.0.action.0.configuration.OAuthToken: \"wefwf\" => \"dfdff\" ",
 		" stage.0.action.0.configuration.OAuthToken: \"*****\" => \"*****\" ", "0.12"},
 	{" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ",
-		" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ", "0.12"},
+		" stage.0.action.0.configuration.DontObfuscate: <*****> => <*****> ", "0.12"},
 	{"random_id.some_id: Refreshing state... [id=itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ]",
 		"random_id.some_id: Refreshing state... [id=********************************************************************************]",
 		"0.12"},
+	// the id value isn't sensitive with random_string.some_password
 	{"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
-		"random_string.some_password: Refreshing state... [id=****************]",
+		"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
 		"0.12"},
+	{" id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
+		" id:               \"**************************************************************************************\" => <computed> (forces new resource)",
+		"0.11"},
 }
 
 func TestProcessLine(t *testing.T) {
@@ -49,10 +57,10 @@ func TestProcessLine(t *testing.T) {
 		// Pattern representing sensitive output
 		var tfmaskValuesRegex = "(?i)^.*(oauth|secret|token|password|key|result).*$"
 		// Pattern representing sensitive resource
-		var tfmaskResourceRegex = "(?i)^(random_id|random_string).*$"
+		var tfmaskResourceRegex = "(?i)^(random_id).*$"
 		// stage.0.action.0.configuration.OAuthToken: "" => "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 		reTfPlanLine := regexp.MustCompile("^( +)([a-zA-Z0-9%._-]+):( +)([\"<])(.*?)([>\"]) +=> +([\"<])(.*)([>\"])(.*)$")
-		currentResource := getCurrentResource(line)
+		currentResource := getCurrentResource("random_id.some_id", line)
 		reTfValues := regexp.MustCompile(tfmaskValuesRegex)
 		reTfResource := regexp.MustCompile(tfmaskResourceRegex)
 		result := processLine(versionedExpressions[lineTest.minorVersion],
@@ -65,11 +73,30 @@ func TestProcessLine(t *testing.T) {
 	}
 }
 
+var currrentResourceTests = []struct {
+	currentResource string
+	line            string
+	expectedResult  string
+}{
+	{"", "-/+ random_string.postgres_admin_password (tainted) (new resource required)",
+		"random_string.postgres_admin_password",
+	},
+	// existing currentResource should persist:
+	{
+		"random_string.postgres_admin_password",
+		" id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
+		"random_string.postgres_admin_password",
+	},
+}
+
 func TestGetCurrentResource(t *testing.T) {
-	result := getCurrentResource("-/+ random_string.postgres_admin_password (tainted) (new resource required)")
-	expectedResult := "random_string.postgres_admin_password"
-	if result != expectedResult {
-		t.Errorf("Got %s, want %s", result, expectedResult)
+	for _, currrentResourceTest := range currrentResourceTests {
+		result := getCurrentResource(currrentResourceTest.currentResource,
+			currrentResourceTest.line)
+		expectedResult := currrentResourceTest.expectedResult
+		if result != expectedResult {
+			t.Errorf("Got %s, want %s", result, expectedResult)
+		}
 	}
 }
 
@@ -84,9 +111,10 @@ var planStatusTests = []struct {
 		"random_id.some_id: Refreshing state... (ID: ********************************************************************************)",
 		"0.11",
 	},
+	// the id value isn't sensitive with random_string.some_password:
 	{
 		"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
-		"random_string.some_password: Refreshing state... (ID: ****************)",
+		"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
 		"0.11",
 	},
 	// tf 0.12 ------------------------------------
@@ -95,15 +123,16 @@ var planStatusTests = []struct {
 		"random_id.some_id: Refreshing state... [id=********************************************************************************]",
 		"0.12",
 	},
+	// the id value isn't sensitive with random_string.some_password:
 	{
 		"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
-		"random_string.some_password: Refreshing state... [id=****************]",
+		"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
 		"0.12",
 	},
 }
 
 func TestPlanStatus(t *testing.T) {
-	var tfmaskResourceRegex = regexp.MustCompile("(?i)^(random_id|random_string).*$")
+	var tfmaskResourceRegex = regexp.MustCompile("(?i)^(random_id).*$")
 	for _, planStatusTest := range planStatusTests {
 		result := planStatus(
 			versionedExpressions[planStatusTest.minorVersion].planStatusRegex,

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var lineTests = []struct {
+	line           string
+	expectedResult string
+	minorVersion   string
+}{
+	// tf 0.11 ------------------------------------
+	{"not_secret", "not_secret", "0.11"},
+	{" stage.0.action.0.configuration.OAuthToken: <wefwf> => <dfdff> ",
+		" stage.0.action.0.configuration.OAuthToken: <*****> => <*****> ", "0.11"},
+	{" stage.0.action.0.configuration.OAuthToken: \"wefwf\" => \"dfdff\" ",
+		" stage.0.action.0.configuration.OAuthToken: \"*****\" => \"*****\" ", "0.11"},
+	{" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ",
+		" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ", "0.11"},
+	{"random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)",
+		"random_id.some_id: Refreshing state... (ID: ********************************************************************************)",
+		"0.11"},
+	{"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
+		"random_string.some_password: Refreshing state... (ID: ****************)",
+		"0.11"},
+	// tf 0.12 ------------------------------------
+	{"not_secret", "not_secret", "0.12"},
+	{" stage.0.action.0.configuration.OAuthToken: <wefwf> => <dfdff> ",
+		" stage.0.action.0.configuration.OAuthToken: <*****> => <*****> ", "0.12"},
+	{" stage.0.action.0.configuration.OAuthToken: \"wefwf\" => \"dfdff\" ",
+		" stage.0.action.0.configuration.OAuthToken: \"*****\" => \"*****\" ", "0.12"},
+	{" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ",
+		" stage.0.action.0.configuration.DontObfuscate: <wefwf> => <dfdff> ", "0.12"},
+	{"random_id.some_id: Refreshing state... [id=itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ]",
+		"random_id.some_id: Refreshing state... [id=********************************************************************************]",
+		"0.12"},
+	{"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
+		"random_string.some_password: Refreshing state... [id=****************]",
+		"0.12"},
+}
+
+func TestProcessLine(t *testing.T) {
+	for _, lineTest := range lineTests {
+		line := lineTest.line
+		// Character used to mask sensitive output
+		var tfmaskChar = "*"
+		// Pattern representing sensitive output
+		var tfmaskValuesRegex = "(?i)^.*(oauth|secret|token|password|key|result).*$"
+		// Pattern representing sensitive resource
+		var tfmaskResourceRegex = "(?i)^(random_id|random_string).*$"
+		// stage.0.action.0.configuration.OAuthToken: "" => "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+		reTfPlanLine := regexp.MustCompile("^( +)([a-zA-Z0-9%._-]+):( +)([\"<])(.*?)([>\"]) +=> +([\"<])(.*)([>\"])(.*)$")
+		currentResource := getCurrentResource(line)
+		reTfValues := regexp.MustCompile(tfmaskValuesRegex)
+		reTfResource := regexp.MustCompile(tfmaskResourceRegex)
+		result := processLine(versionedExpressions[lineTest.minorVersion],
+			reTfPlanLine, reTfResource, reTfValues, tfmaskChar, currentResource, line)
+		result = strings.TrimSuffix(result, "\n")
+		expectedResult := lineTest.expectedResult
+		if result != expectedResult {
+			t.Errorf("Got %s, want %s", result, expectedResult)
+		}
+	}
+}
+
+func TestGetCurrentResource(t *testing.T) {
+	result := getCurrentResource("-/+ random_string.postgres_admin_password (tainted) (new resource required)")
+	expectedResult := "random_string.postgres_admin_password"
+	if result != expectedResult {
+		t.Errorf("Got %s, want %s", result, expectedResult)
+	}
+}
+
+var planStatusTests = []struct {
+	line           string
+	expectedResult string
+	minorVersion   string
+}{
+	// tf 0.11 ------------------------------------
+	{
+		"random_id.some_id: Refreshing state... (ID: itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ)",
+		"random_id.some_id: Refreshing state... (ID: ********************************************************************************)",
+		"0.11",
+	},
+	{
+		"random_string.some_password: Refreshing state... (ID: 2iB@@h22@12kA2qE)",
+		"random_string.some_password: Refreshing state... (ID: ****************)",
+		"0.11",
+	},
+	// tf 0.12 ------------------------------------
+	{
+		"random_id.some_id: Refreshing state... [id=itILf4x5lqleQV9ZwT2gH-Zg3yuXM8pdUu6VFTX...P5vqUmggDweOoxFMPY5t9thA0SJE2EZIhcHbsQ]",
+		"random_id.some_id: Refreshing state... [id=********************************************************************************]",
+		"0.12",
+	},
+	{
+		"random_string.some_password: Refreshing state... [id=2iB@@h22@12kA2qE]",
+		"random_string.some_password: Refreshing state... [id=****************]",
+		"0.12",
+	},
+}
+
+func TestPlanStatus(t *testing.T) {
+	var tfmaskResourceRegex = regexp.MustCompile("(?i)^(random_id|random_string).*$")
+	for _, planStatusTest := range planStatusTests {
+		result := planStatus(
+			versionedExpressions[planStatusTest.minorVersion].planStatusRegex,
+			tfmaskResourceRegex, "*",
+			planStatusTest.line)
+		if result != planStatusTest.expectedResult {
+			t.Errorf("Got %s, want %s", result, planStatusTest.expectedResult)
+		}
+	}
+}


### PR DESCRIPTION
Adds support for terraform v0.12

On the face of it this will look like a tonne of changes so I'll make an attempt at summarising:

- refactored most regex processing logic out of the main() func into various dedicated functions. I tried to keep as much code as I could the same when copying over.
- added struct called `match` which holds all of the regex group matches from `retfplanline`. This wasn't exactly necessary but felt cleaner holding it all in its own struct
- added an `expression` struct, which holds regexes that differ between versions of terraform.
- added a `versionedExpressions` map which maps terraform version to an `expression`
- added a switch via env var `TFENV` so users can use tf 0.12 (defaults to tf 0.11)
- regexes for tf 0.12 (was planning on trying to make the original regexes applicable to both versions but it became too cumbersome)
- unit tests for both tf 0.11 & 0.12 in `main_tests.go`

In terms of testing, I've done a diff (see attached) of the outputs from running `make test` with tf 0.11 in the `/tests` directory, on the latest binary you've released Vs. a binary I've built from my branch. I think it's come out well; just a few differences where the id of the `random_string.some_password` is different (which is fine).
[tf-011-old-vs-new-diff.txt](https://github.com/cloudposse/tfmask/files/4516099/tf-011-old-vs-new-diff.txt)

For what it's worth, I've also run `make test` with tf 0.12 (see attached output). This looks okay to me but might need some sanity checking.
[tf012_test.txt](https://github.com/cloudposse/tfmask/files/4516122/tf012_test.txt)