### PR TITLE
Increase MaxBufferSize

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,9 +108,16 @@ func main() {
 	// Default to tf 0.12, but users can override
 	var tfenv = getEnv("TFENV", "0.12")
 
+	defaultBufferSize := make([]byte, 4096)
+
+	// The default size is 64 * 1024: https://pkg.go.dev/bufio#pkg-constants
+	// Set it to 10 times the default MaxScanTokenSize
+	maxBufferSize := bufio.MaxScanTokenSize * 10
+
 	reTfValues := regexp.MustCompile(tfmaskValuesRegex)
 	reTfResource := regexp.MustCompile(tfmaskResourceRegex)
 	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(defaultBufferSize, maxBufferSize)
 	versionedExpressions := versionedExpressions[tfenv]
 	// initialize currentResource once before scanning
 	currentResource := ""


### PR DESCRIPTION
We've hit on some situations where `tfmask` would hit this error:

```
bufio.Scanner: token too long
```

This was because some of the lines in our output were exceeding the default [`MaxScanTokenSize`](https://golang.org/pkg/bufio/#pkg-constants) in `bufio.Scanner`

This change increases the buffer by 10.